### PR TITLE
Refactor:SystemType Adds to prevent conflicts

### DIFF
--- a/Submerged/Enums/CustomSystemTypes.cs
+++ b/Submerged/Enums/CustomSystemTypes.cs
@@ -8,7 +8,7 @@ public readonly struct CustomSystemTypes
 {
     public static void Initialize()
     {
-        SystemTypeHelpers.AllTypes = Enum.GetValues<SystemTypes>().Concat(All.Select(t => t.systemType)).ToArray();
+        SystemTypeHelpers.AllTypes = SystemTypeHelpers.AllTypes.Concat(All.Select(t => t.systemType)).ToArray();
     }
 
     #region Struct implementation

--- a/Submerged/Enums/CustomSystemTypes.cs
+++ b/Submerged/Enums/CustomSystemTypes.cs
@@ -6,7 +6,7 @@ namespace Submerged.Enums;
 
 public readonly struct CustomSystemTypes
 {
-    public static void Initialize()
+    internal static void Initialize()
     {
         SystemTypeHelpers.AllTypes = SystemTypeHelpers.AllTypes.Concat(All.Select(t => t.systemType)).ToArray();
     }


### PR DESCRIPTION
Depending on the order in which they are loaded, SystemType added by another mod may be overwritten by Submerged. This is the fix for that.