### PR TITLE
Fix: UNT0008 (https://github.com/microsoft/Microsoft.Unity.Analyzers/blob/main/doc/UNT0008.md)

### DIFF
--- a/Submerged/ExileCutscene/FishController.cs
+++ b/Submerged/ExileCutscene/FishController.cs
@@ -66,8 +66,14 @@ public sealed class FishController(nint ptr) : MonoBehaviour(ptr)
 
     public void Closed()
     {
-        targetObj!?.gameObject.SetActive(false);
-        bubbles!?.Stop();
+        if (targetObj != null)
+        {
+            targetObj.gameObject.SetActive(false);
+        }
+        if (bubbles != null)
+        {
+            bubbles.Stop();
+        }
         this.StartCoroutine(LerpSpeed(0.5f, _speed, 25f));
     }
 

--- a/Submerged/Extensions/ComponentExtensions.cs
+++ b/Submerged/Extensions/ComponentExtensions.cs
@@ -33,9 +33,11 @@ public static class ComponentExtensions
         }
     }
 
-    public static T EnsureComponent<T>(this GameObject obj) where T : Component => obj.GetComponent<T>() ?? obj.AddComponent<T>();
+    public static T EnsureComponent<T>(this GameObject obj) where T : Component =>
+        obj.TryGetComponent<T>(out T comp) ? comp : obj.AddComponent<T>();
 
-    public static Component EnsureComponent(this GameObject obj, Type type) => obj.GetComponent(Il2CppType.From(type)) ?? obj.AddComponent(Il2CppType.From(type));
+    public static Component EnsureComponent(this GameObject obj, Type type)
+        => obj.TryGetComponent(Il2CppType.From(type), out Component comp) ? comp : obj.AddComponent(Il2CppType.From(type));
 
     public static Component AddInjectedComponentByName(this GameObject obj, string typeName) => obj.AddComponent(Il2CppType.From(RegisteredTypes[typeName]));
 }

--- a/Submerged/Minigames/CustomMinigames/CleanGlass/CleanGlassMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/CleanGlass/CleanGlassMinigame.cs
@@ -56,7 +56,10 @@ public sealed class CleanGlassMinigame(nint ptr) : Minigame(ptr)
     [HideFromIl2Cpp]
     private IEnumerator Sparkle()
     {
-        MyNormTask!?.NextStep();
+        if (MyNormTask != null)
+        {
+            MyNormTask.NextStep();
+        }
         StartCoroutine(CoStartClose());
 
         Animator anim = transform.Find("Sparkle").GetComponent<Animator>();

--- a/Submerged/Minigames/CustomMinigames/ClearUrchins/ClearUrchinsMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/ClearUrchins/ClearUrchinsMinigame.cs
@@ -82,7 +82,10 @@ public sealed class ClearUrchinsMinigame(nint ptr) : Minigame(ptr)
             _finished = CheckFinished();
 
             if (!_finished) return;
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
         }
     }

--- a/Submerged/Minigames/CustomMinigames/DispenseWater/DispenseWaterMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/DispenseWater/DispenseWaterMinigame.cs
@@ -74,19 +74,28 @@ public sealed class DispenseWaterMinigame(nint ptr) : Minigame(ptr)
     {
         if (_filling)
         {
-            _audioSource!?.UnPause();
+            if (_audioSource != null)
+            {
+                _audioSource.UnPause();
+            }
             _timer += Time.deltaTime;
 
             if (_timer > 5f)
             {
                 button.onUp.Invoke();
-                _audioSource!?.Stop();
+                if (_audioSource != null)
+                {
+                    _audioSource.Stop();
+                }
                 Destroy(button);
             }
         }
         else
         {
-            _audioSource!?.Pause();
+            if (_audioSource != null)
+            {
+                _audioSource.Pause();
+            }
             if (waterAnimation.GetCurrentStateName(0) != "EndWater") waterAnimation.Play("EndWater");
         }
 
@@ -97,7 +106,10 @@ public sealed class DispenseWaterMinigame(nint ptr) : Minigame(ptr)
                 cap.position = capTarget.position;
                 capDraggable.forceStop = true;
                 SoundManager.Instance.PlaySound(minigameProperties.audioClips[1], false);
-                MyNormTask!?.NextStep();
+                if (MyNormTask != null)
+                {
+                    MyNormTask.NextStep();
+                }
                 StartCoroutine(CoStartClose());
             }
         }

--- a/Submerged/Minigames/CustomMinigames/FeedPetFish/FeedFishMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/FeedPetFish/FeedFishMinigame.cs
@@ -74,7 +74,10 @@ public sealed class FeedFishMinigame(nint ptr) : Minigame(ptr)
 
         if (_completedSpecies[0] && _completedSpecies[1] && amClosing == CloseState.None)
         {
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
         }
     }

--- a/Submerged/Minigames/CustomMinigames/IdentifySpecimen/IdentifySpecimenMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/IdentifySpecimen/IdentifySpecimenMinigame.cs
@@ -31,7 +31,10 @@ public sealed class IdentifySpecimenMinigame(nint ptr) : Minigame(ptr)
     private void CompleteTask()
     {
         if (amClosing != CloseState.None) return;
-        MyNormTask!?.NextStep();
+        if (MyNormTask != null)
+        {
+            MyNormTask.NextStep();
+        }
         StartCoroutine(CoStartClose());
     }
 }

--- a/Submerged/Minigames/CustomMinigames/LocateVolcanicActivity/LocateVolcanicActivityMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/LocateVolcanicActivity/LocateVolcanicActivityMinigame.cs
@@ -154,7 +154,10 @@ public sealed class LocateVolcanicActivityMinigame(nint ptr) : Minigame(ptr)
     [HideFromIl2Cpp]
     public IEnumerator CoWipeScreen()
     {
-        MyNormTask!?.NextStep();
+        if (MyNormTask != null)
+        {
+            MyNormTask.NextStep();
+        }
         StartCoroutine(CoStartClose());
 
         transform.Find("NewText/EnabledText").gameObject.SetActive(false);

--- a/Submerged/Minigames/CustomMinigames/OxygenateSeaPlants/OxygenateCoralMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/OxygenateSeaPlants/OxygenateCoralMinigame.cs
@@ -295,7 +295,10 @@ public sealed class OxygenateCoralMinigame(nint ptr) : Minigame(ptr)
     public IEnumerator Oxygenate()
     {
         if (amClosing != CloseState.None) yield break;
-        MyNormTask!?.NextStep();
+        if (MyNormTask != null)
+        {
+            MyNormTask.NextStep();
+        }
         StartCoroutine(CoStartClose());
 
         _bubbleTransform.gameObject.SetActive(false);

--- a/Submerged/Minigames/CustomMinigames/ReconnectPiping/ReconnectPipingMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/ReconnectPiping/ReconnectPipingMinigame.cs
@@ -124,7 +124,10 @@ public sealed class ReconnectPipingMinigame(nint ptr) : Minigame(ptr)
         needle.movementType = NeedleBehaviour.Movement.RandomBounce;
 
         Transform valve = transform.Find("Valve");
-        MyNormTask!?.NextStep();
+        if (MyNormTask != null)
+        {
+            MyNormTask.NextStep();
+        }
         StartCoroutine(CoStartClose());
         this.StartCoroutine(SpinItem(valve));
     }

--- a/Submerged/Minigames/CustomMinigames/ResetBreakers/ResetBreakersMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/ResetBreakers/ResetBreakersMinigame.cs
@@ -48,8 +48,10 @@ public sealed class ResetBreakersMinigame(nint ptr) : Minigame(ptr)
             {
                 circutBreaker.enabled = false;
             }
-
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
         }
     }

--- a/Submerged/Minigames/CustomMinigames/ReshelveBooks/ReshelvePart1.cs
+++ b/Submerged/Minigames/CustomMinigames/ReshelveBooks/ReshelvePart1.cs
@@ -39,19 +39,22 @@ public sealed class ReshelvePart1(nint ptr) : MonoBehaviour(ptr)
             this.StartCoroutine(CoOnMouseDown(clickableSprite.gameObject));
         };
 
-        transform.Find("Books/Benthic Beasts")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book02_Lounge);
-        transform.Find("Books/Ichthyologist Weekly")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book06_Lounge);
-        transform.Find("Books/Octopus Digest")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book11_Lounge);
-        transform.Find("Books/Kelper Worms")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book08_Medical);
-        transform.Find("Books/Nautical Nonsense")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book10_Medical);
-        transform.Find("Books/Sea Slugs & You!")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book13_Medical);
+        SetText("Books/Benthic Beasts", Tasks.ReshelveBooks_Book02_Lounge);
+        SetText("Books/Ichthyologist Weekly", Tasks.ReshelveBooks_Book06_Lounge);
+        SetText("Books/Octopus Digest", Tasks.ReshelveBooks_Book11_Lounge);
+        SetText("Books/Kelper Worms", Tasks.ReshelveBooks_Book08_Medical);
+        SetText("Books/Nautical Nonsense", Tasks.ReshelveBooks_Book10_Medical);
+        SetText("Books/Sea Slugs & You!", Tasks.ReshelveBooks_Book13_Medical);
     }
 
     [HideFromIl2Cpp]
     private IEnumerator CoOnMouseDown(GameObject obj)
     {
         minigame.Task.customData[minigame.ConsoleId + 2] = 1;
-        minigame.Task!?.NextStep();
+        if (minigame.Task != null)
+        {
+            minigame.Task.NextStep();
+        }
 
         SpriteRenderer rend = obj.GetComponent<SpriteRenderer>();
         TextMeshPro text = obj.GetComponentInChildren<TextMeshPro>();
@@ -64,5 +67,15 @@ public sealed class ReshelvePart1(nint ptr) : MonoBehaviour(ptr)
         }
 
         minigame.minigameProperties.CloseTask();
+    }
+
+    private void SetText(string objName, string targetText)
+    {
+        Transform targetTrans = transform.Find(objName);
+        if (targetTrans == null)
+        {
+            return;
+        }
+        targetTrans.GetComponentInChildren<TextMeshPro>().SetText(targetText);
     }
 }

--- a/Submerged/Minigames/CustomMinigames/ReshelveBooks/ReshelvePart2.cs
+++ b/Submerged/Minigames/CustomMinigames/ReshelveBooks/ReshelvePart2.cs
@@ -50,37 +50,40 @@ public sealed class ReshelvePart2(nint ptr) : MonoBehaviour(ptr)
             draggable.onUp += () => OnDragEnd(rend);
         }
 
-        books.Find("Benthic Beasts")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book02_Lounge);
-        books.Find("Ichthyologist Weekly")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book06_Lounge);
-        books.Find("Octopus Digest")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book11_Lounge);
-        books.Find("Kelper Worms")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book08_Medical);
-        books.Find("Nautical Nonsense")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book10_Medical);
-        books.Find("Sea Slugs & You!")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book13_Medical);
+        SetText(books, "Benthic Beasts", Tasks.ReshelveBooks_Book02_Lounge);
+        SetText(books, "Ichthyologist Weekly", Tasks.ReshelveBooks_Book06_Lounge);
+        SetText(books, "Octopus Digest", Tasks.ReshelveBooks_Book11_Lounge);
+        SetText(books, "Kelper Worms", Tasks.ReshelveBooks_Book08_Medical);
+        SetText(books, "Nautical Nonsense", Tasks.ReshelveBooks_Book10_Medical);
+        SetText(books, "Sea Slugs & You!", Tasks.ReshelveBooks_Book13_Medical);
 
         Transform drop = transform.Find("DropZoneIndicators");
-        drop.Find("Benthic Beasts")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book02_Lounge);
-        drop.Find("Ichthyologist Weekly")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book06_Lounge);
-        drop.Find("Octopus Digest")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book11_Lounge);
-        drop.Find("Kelper Worms")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book08_Medical);
-        drop.Find("Nautical Nonsense")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book10_Medical);
-        drop.Find("Sea Slugs & You!")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book13_Medical);
+        SetText(drop, "Benthic Beasts", Tasks.ReshelveBooks_Book02_Lounge);
+        SetText(drop, "Ichthyologist Weekly", Tasks.ReshelveBooks_Book06_Lounge);
+        SetText(drop, "Octopus Digest", Tasks.ReshelveBooks_Book11_Lounge);
+        SetText(drop, "Kelper Worms", Tasks.ReshelveBooks_Book08_Medical);
+        SetText(drop, "Nautical Nonsense", Tasks.ReshelveBooks_Book10_Medical);
+        SetText(drop, "Sea Slugs & You!", Tasks.ReshelveBooks_Book13_Medical);
 
-        transform.Find("Background/A")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book01);
-        transform.Find("Background/C")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book03);
-        transform.Find("Background/E")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book04);
-        transform.Find("Background/F")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book05);
-        transform.Find("Background/J")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book07);
-        transform.Find("Background/M")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book09);
-        transform.Find("Background/P")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book12);
-        transform.Find("Background/V")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book14);
-        transform.Find("Background/W")?.GetComponentInChildren<TextMeshPro>().SetText(Tasks.ReshelveBooks_Book15);
+        SetText(transform, "Background/A", Tasks.ReshelveBooks_Book01);
+        SetText(transform, "Background/C", Tasks.ReshelveBooks_Book03);
+        SetText(transform, "Background/E", Tasks.ReshelveBooks_Book04);
+        SetText(transform, "Background/F", Tasks.ReshelveBooks_Book05);
+        SetText(transform, "Background/J", Tasks.ReshelveBooks_Book07);
+        SetText(transform, "Background/M", Tasks.ReshelveBooks_Book09);
+        SetText(transform, "Background/P", Tasks.ReshelveBooks_Book12);
+        SetText(transform, "Background/V", Tasks.ReshelveBooks_Book14);
+        SetText(transform, "Background/W", Tasks.ReshelveBooks_Book15);
     }
 
     private void Update()
     {
         if (remainingBooks == 0)
         {
-            minigame.Task!?.NextStep();
+            if (minigame.Task != null)
+            {
+                minigame.Task.NextStep();
+            }
             minigame.StartCoroutine(minigame.CoStartClose());
             remainingBooks = -1;
         }
@@ -146,5 +149,15 @@ public sealed class ReshelvePart2(nint ptr) : MonoBehaviour(ptr)
     {
         if (_stopClose) return;
         minigame.minigameProperties.CloseTask();
+    }
+
+    private void SetText(Transform search, string objName, string targetText)
+    {
+        Transform targetTrans = search.Find(objName);
+        if (targetTrans == null)
+        {
+            return;
+        }
+        targetTrans.GetComponentInChildren<TextMeshPro>().SetText(targetText);
     }
 }

--- a/Submerged/Minigames/CustomMinigames/RetrieveOxygenMask/OxygenSabotageTask.cs
+++ b/Submerged/Minigames/CustomMinigames/RetrieveOxygenMask/OxygenSabotageTask.cs
@@ -95,7 +95,11 @@ public sealed class OxygenSabotageTask(nint ptr) : PlayerTask(ptr)
     {
         isComplete = true;
         PlayerControl.LocalPlayer.RemoveTask(this);
-        FindObjectOfType<OxygenSabotageMinigame>()?.Close();
+        OxygenSabotageMinigame minigame = FindObjectOfType<OxygenSabotageMinigame>();
+        if (minigame != null)
+        {
+            minigame.Close();
+        }
     }
 
     public override void OnRemove() { }

--- a/Submerged/Minigames/CustomMinigames/SortScubaGear/SortScubaMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/SortScubaGear/SortScubaMinigame.cs
@@ -78,7 +78,10 @@ public sealed class SortScubaMinigame(nint ptr) : Minigame(ptr)
                 if (CheckBoxes())
                 {
                     _forceClose = true;
-                    MyNormTask!?.NextStep();
+                    if (MyNormTask != null)
+                    {
+                        MyNormTask.NextStep();
+                    }
                     StartCoroutine(CoStartClose());
                 }
             };

--- a/Submerged/Minigames/CustomMinigames/SpotWhaleShark/WhaleSharkMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/SpotWhaleShark/WhaleSharkMinigame.cs
@@ -32,7 +32,10 @@ public sealed class WhaleSharkMinigame(nint ptr) : Minigame(ptr)
         _button.onDown += () =>
         {
             if (!_task.visible || _finished) return;
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose(1f));
             _finished = true;
         };

--- a/Submerged/Minigames/CustomMinigames/StartSubmersible/StartSubmersibleMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/StartSubmersible/StartSubmersibleMinigame.cs
@@ -67,7 +67,10 @@ public sealed class StartSubmersibleMinigame(nint ptr) : Minigame(ptr)
         {
             text.text = Tasks.StartSubmersible_Status_Active;
             _audio.Stop();
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
         }
     }
@@ -181,7 +184,10 @@ public sealed class StartSubmersibleMinigame(nint ptr) : Minigame(ptr)
 
         for (int i = 0; i < 3; i++)
         {
-            switches.GetChild(i).Find("Off/OffSwitch").GetComponent<SpriteRenderer>()?.material.SetFloat("_Outline", 1);
+            if (switches.GetChild(i).Find("Off/OffSwitch").TryGetComponent(out SpriteRenderer rend))
+            {
+                rend.material.SetFloat("_Outline", 1);
+            }
         }
     }
 

--- a/Submerged/Minigames/CustomMinigames/SteadyHeartbeat/SteadyHeartbeatMinigame.cs
+++ b/Submerged/Minigames/CustomMinigames/SteadyHeartbeat/SteadyHeartbeatMinigame.cs
@@ -69,7 +69,10 @@ public sealed class SteadyHeartbeatMinigame(nint ptr) : Minigame(ptr)
         {
             Color32 col = new(30, 150, 0, 255);
             _statusText.text = string.Format(Tasks.SteadyHeartbeat_Status, $"<color=#{col.r:X2}{col.g:X2}{col.b:X2}{col.a:X2}>{Tasks.SteadyHeartbeat_Status_Stable}</color>");
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
         }
 

--- a/Submerged/Minigames/CustomMinigames/TrackMantaRay/TrackMantaRay.cs
+++ b/Submerged/Minigames/CustomMinigames/TrackMantaRay/TrackMantaRay.cs
@@ -79,7 +79,10 @@ public sealed class TrackMantaMinigame(nint ptr) : Minigame(ptr)
         if (percent >= 100)
         {
             if (amClosing != CloseState.None) return;
-            MyNormTask!?.NextStep();
+            if (MyNormTask != null)
+            {
+                MyNormTask.NextStep();
+            }
             StartCoroutine(CoStartClose());
 
             foreach (TextMeshPro t in _textMeshPros)

--- a/Submerged/Submerged.csproj
+++ b/Submerged/Submerged.csproj
@@ -27,6 +27,10 @@
         <PackageReference Include="BepInEx.IL2CPP.MSBuild" Version="2.1.0-rc.1" PrivateAssets="all" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" Aliases="JetBrains" PrivateAssets="all" />
         <PackageReference Include="Resource.Embedder" Version="2.2.1-submerged" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.Unity.Analyzers" Version="1.22.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Unity overrides the null check, which causes unexpected behavior when using null-related operators(using [this analyzer](https://github.com/microsoft/Microsoft.Unity.Analyzers))

In fact, my mod ExR was causing unexpected behavior by using null-related operators, so I guess this will fix the strange issuess and crashes of Submerged (ExR has been using MS's Unity analyzer for quite a while now, which prevents these accidents)
